### PR TITLE
remove key mappings

### DIFF
--- a/ftplugin/python/pyflakes.vim
+++ b/ftplugin/python/pyflakes.vim
@@ -157,14 +157,6 @@ if !exists(":PyflakesUpdate")
   command PyflakesUpdate :call s:PyflakesUpdate()
 endif
 
-" Hook common text manipulation commands to update PyFlakes
-"   TODO: is there a more general "text op" autocommand we could register
-"   for here?
-noremap <buffer><silent> dd dd:PyflakesUpdate<CR>
-noremap <buffer><silent> dw dw:PyflakesUpdate<CR>
-noremap <buffer><silent> u u:PyflakesUpdate<CR>
-noremap <buffer><silent> <C-R> <C-R>:PyflakesUpdate<CR>
-
 " WideMsg() prints [long] message up to (&columns-1) length
 " guaranteed without "Press Enter" prompt.
 if !exists("*s:WideMsg")


### PR DESCRIPTION
These key mappings cause problems even in a default config, and I don't think they're useful.  They'll be even worse for folks who have remapped keys.

If you'd like to keep the remappings, let's figure out a way to make them optional, and to get them right for the default case (by mapping 'd' instead of 'dd' in visual mode, for starters).
