### PR TITLE
Fix for Pyflakes spurious error on systems with source control integration

### DIFF
--- a/ftplugin/python/pyflakes.vim
+++ b/ftplugin/python/pyflakes.vim
@@ -202,6 +202,7 @@ if !exists("*s:ActivatePyflakesQuickFixWindow")
         try
             silent colder 9 " go to the bottom of quickfix stack
         catch /E380:/
+        catch /E788:/
         endtry
 
         if s:pyflakes_qf > 0


### PR DESCRIPTION
When using a hook on FileChangedRO to allow file editing (e.g. checking out a file from source control), Pyflakes attempts to change buffers and E788 is raised.  Catching this here means that this silently fails, and Pyflakes will be called again once the file is editable
