### PR TITLE
now pyflake could be toggled on and off

### DIFF
--- a/ftplugin/python/pyflakes.vim
+++ b/ftplugin/python/pyflakes.vim
@@ -145,12 +145,12 @@ if !exists("*s:PyflakesToggle")
             silent call s:RunPyflakes()
             echo 'pyflake on'
 
-            au BufEnter <buffer> call s:RunPyflakes()
+            "au BufEnter <buffer> call s:RunPyflakes()
             au InsertLeave <buffer> call s:RunPyflakes()
             au InsertEnter <buffer> call s:RunPyflakes()
             au BufWritePost <buffer> call s:RunPyflakes()
 
-            au CursorHold <buffer> call s:RunPyflakes()
+            "au CursorHold <buffer> call s:RunPyflakes()
             au CursorHoldI <buffer> call s:RunPyflakes()
 
             au CursorHold <buffer> call s:GetPyflakesMessage()

--- a/ftplugin/python/pyflakes.vim
+++ b/ftplugin/python/pyflakes.vim
@@ -304,7 +304,7 @@ EOF
                 call setqflist(b:qf_list, 'r')
             else
                 " one pyflakes quickfix window for all buffer
-                call setqflist(b:qf_list, '')
+                call setqflist(b:qf_list, ' ')
                 let s:pyflakes_qf = s:GetQuickFixStackCount()
             endif
         endif


### PR DESCRIPTION
I'd like to run pyflake on demand, rather than turn it on by default.
new option 'g:pyflakes_autostart' was added correspondingly, 
