### PR TITLE
Allow for a global var to be filled when errors are present.

### DIFF
--- a/ftplugin/python/pyflakes.vim
+++ b/ftplugin/python/pyflakes.vim
@@ -33,6 +33,7 @@ if !exists('g:pyflakes_use_quickfix')
     let g:pyflakes_use_quickfix = 1
 endif
 
+let g:pyflakes_has_errors = 0
 
     python << EOF
 import vim
@@ -67,6 +68,7 @@ class blackhole(object):
     write = flush = lambda *a, **k: None
 
 def check(buffer):
+    vim.command("let g:pyflakes_has_errors = 0")
     filename = buffer.name
     contents = buffer[:]
 
@@ -259,6 +261,7 @@ for w in check(vim.current.buffer):
         vim.command("let l:qf_item.vcol = 1")
         vim.command("let l:qf_item.col = %s" % str(w.col + 1))
 
+    vim.command("let g:pyflakes_has_errors = 1")
     vim.command("call add(b:matched, s:matchDict)")
     vim.command("call add(b:qf_list, l:qf_item)")
 EOF


### PR DESCRIPTION
This global variable that is added allows a door for functions and other tools to be aware of when pyflakes has found errors.

This especially useful when huge files have errors that pyflakes has detected but you are not currently able to visualize those errors since they are not in a range to do so.

A statusline function (for example) would be able to pick this up and notify the user appropriately.
