### PR TITLE
Fix AttributeError: 'NoneType' when file name not set.

### DIFF
--- a/ftplugin/python/pyflakes.vim
+++ b/ftplugin/python/pyflakes.vim
@@ -115,6 +115,7 @@ def check(buffer):
         old_globals = getattr(checker,' _MAGIC_GLOBALS', [])
         checker._MAGIC_GLOBALS = set(old_globals) | builtins
 
+        filename = '(none)' if filename is None else filename
         w = checker.Checker(tree, filename)
 
         checker._MAGIC_GLOBALS = old_globals


### PR DESCRIPTION
Hi,

I've got errors when buffer name is not set. 
1. Run MacVim.app
2. :set ft=python
3. input like `aaa = bbb`
4. Raise exception
   Error detected while processing function <SNR>146_RunPyflakes:
   line 45:

When buffer name does not set, `buffer.name` is `None`. 
`checker.Checker(tree, filename)`'s filename arg excepted `'(none)'`.

This patch set `'(none)'` to filename when no buffer name.

Regards,
