### PR TITLE
making the submodule public access

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "ftplugin/python/pyflakes"]
 	path = ftplugin/python/pyflakes
-	url = git://github.com/pyflakes/pyflakes.git
+	url = https://github.com/pyflakes/pyflakes.git


### PR DESCRIPTION
makes the submodule public so that you don't have to have .ssh key or github token access preconfigured to use the submodule based install
