### PR TITLE
pyflakes.vim: pass a valid action to setqflist

### DIFF
--- a/ftplugin/python/pyflakes.vim
+++ b/ftplugin/python/pyflakes.vim
@@ -277,7 +277,7 @@ EOF
                 call setqflist(b:qf_list, 'r')
             else
                 " one pyflakes quickfix window for all buffer
-                call setqflist(b:qf_list, '')
+                call setqflist(b:qf_list, ' ')
                 let s:pyflakes_qf = s:GetQuickFixStackCount()
             endif
         endif


### PR DESCRIPTION
Vim 7.4 [1] on Debian/testing does stricter error checking of
arguments and setqflist will now throw an error when given an
empty string as its {action} parameter.

Pass ' ' so that a new quickfix window is created.

[1] https://github.com/vim/vim/commit/d106e5ba7f10f0d2a14eaefe5d78405044416cb9

Signed-off-by: David Aguilar davvid@gmail.com
