### PR TITLE
MRG: needed import of SyntaxError too

### DIFF
--- a/ftplugin/python/pyflakes.vim
+++ b/ftplugin/python/pyflakes.vim
@@ -53,7 +53,7 @@ for path in (script_dir, flakes_dir):
     if path not in sys.path:
         sys.path.insert(0, path)
 
-from flaker import check, vim_quote
+from flaker import check, vim_quote, SyntaxError
 EOF
     let b:did_python_init = 1
 endif


### PR DESCRIPTION
Oops - I missed an import.

Needed to import SyntaxError from Python module, in order to get displayed line
of syntax error correct.