### PR TITLE
MRG: allow choice of Python version in vimrc

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -89,10 +89,23 @@ Options
 -------
 
 Set this option in your vimrc file to disable quickfix support::
-    
+
     let g:pyflakes_use_quickfix = 0
 
 The value is set to 1 by default.
+
+Pyflakes can use Python 2 or Python 3 compiled into Vim.  If you have both,
+you can ask Pyflakes to prefer one or the other, with this in your vimrc::
+
+    let g:pyflakes_prefer_python_version = 3
+
+or::
+
+    let g:pyflakes_prefer_python_version = 2
+
+Pyflakes will chose Python 2 by default, if you have both.  If you prefer a
+version that you don't have, Pyflakes will quietly fall back to the version
+that you do have.
 
 TODO
 ----

--- a/ftplugin/python/pyflakes.vim
+++ b/ftplugin/python/pyflakes.vim
@@ -24,19 +24,32 @@ endif
 if !exists("b:did_python_init")
     let b:did_python_init = 0
 
-    if has('python')
-        command! -nargs=1 Python python <args>
-    elseif has('python3')
-        command! -nargs=1 Python python3 <args>
-    else
-        echo "Error: Requires Vim compiled with +python or +python3"
+    if !has('python') && !has('python3')
+        echoerr "Error: Requires Vim compiled with +python or +python3"
         finish
     endif
+    " Default to Python 2
+    if has('python')
+        let py_cmd_ver = 'python'
+    else
+        let py_cmd_ver = 'python3'
+    endif
+    if exists('g:pyflakes_prefer_python_version')
+        if g:pyflakes_prefer_python_version == 3 && has('python3')
+            let py_cmd_ver = 'python3'
+        elseif g:pyflakes_prefer_python_version == 2 && has('python')
+            let py_cmd_ver = 'python'
+        endif
+    endif
+    if py_cmd_ver == 'python'
+        command! -nargs=1 Python python <args>
+    else
+        command! -nargs=1 Python python3 <args>
+    endif
 
-if !exists('g:pyflakes_use_quickfix')
-    let g:pyflakes_use_quickfix = 1
-endif
-
+    if !exists('g:pyflakes_use_quickfix')
+        let g:pyflakes_use_quickfix = 1
+    endif
 
 Python << EOF
 import vim


### PR DESCRIPTION
Add option to allow choice of Python version, in the odd case that you have
both compiled into your Vim.