### PR TITLE
Fix handling of `ast.SyntaxError` in Python 3.10+

### DIFF
--- a/ftplugin/python/flaker.py
+++ b/ftplugin/python/flaker.py
@@ -75,7 +75,9 @@ def check(buffer):
     except:
         exc_value = sys.exc_info()[1]
         try:
-            lineno, offset, line = exc_value.args[1][1:]
+            lineno = exc_value.lineno
+            offset = exc_value.offset
+            line = exc_value.text
         except IndexError:
             lineno, offset, line = 1, 0, ''
         if line and line.endswith("\n"):


### PR DESCRIPTION
In Python 3.10+, the [`ast.SyntaxError` class in Python 3.10+](https://docs.python.org/3/library/exceptions.html#SyntaxError) has changed such that the following pyflakes-vim code blows up, resulting in a massive spew of error messages in vim whenever a syntax error is encountered:
```
>               lineno, offset, line = exc_value.args[1][1:]
E               ValueError: too many values to unpack (expected 3)
```
This PR fixes the issue by retrieving the desired `SyntaxError` properties using more reliable, direct property access rather than destructuring `exc_value.args[1]` so that it works correctly on newer Python versions (without breaking support for older versions, AFAICT).

---

It looks like this repo is probably dead at this point (e.g. according to the deprecation message in the readme), but I still find pyflakes-vim to be the best Python syntax highlighter for vim because it's so much faster and lighter weight than ALE, so I'm posting this PR in case anyone else is in the same boat.

Until this PR is merged (if ever), a forked version of pyflakes-vim with the fix can be installed by following the install instructions in the forked [kkroening/pyflakes-vim readme](https://github.com/kkroening/pyflakes-vim).